### PR TITLE
Fix wiki links

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -11,6 +11,6 @@ An Escape From Tarkov BepInEx module designed to be used with SPT-Aki with the u
 The Stay in Tarkov project was born due to Battlestate Games' (BSG) reluctance to create the pure PvE version of Escape from Tarkov. 
 The project's aim is simple, create a Cooperation PvE experience that retains progression. If BSG decide to create the ability to do this on live, this project will be shut down immediately.
 
-## [Guides](./Guides)
-## [FAQs](./FAQs)
+## [Guides](https://github.com/paulov-t/SIT.Core/wiki/Guides)
+## [FAQs](https://github.com/paulov-t/SIT.Core/wiki/FAQs)
 ## [中文WIKI](家 - Home)

--- a/wiki/en/Guides.md
+++ b/wiki/en/Guides.md
@@ -1,6 +1,6 @@
 Useful Guides:
 
-- [SETUP-STANDARD.md](./Guides/SETUP-STANDARD.md)
-- [SETUP-HAMACHI.md](./Guides/SETUP-HAMACHI.md) by [ppyLEK](https://github.com/ppyLEK)
-- [HOSTING](./Guides/HOSTING.md)
-- [Step by step installation guide](./Guides/Step-By-Step-Installation-Guide.md) by [jeremymouton](https://github.com/jeremymouton)
+- [SETUP-STANDARD](https://github.com/paulov-t/SIT.Core/wiki/SETUP-STANDARD)
+- [SETUP-HAMACHI](https://github.com/paulov-t/SIT.Core/wiki/SETUP-HAMACHI) by [ppyLEK](https://github.com/ppyLEK)
+- [HOSTING](https://github.com/paulov-t/SIT.Core/wiki/HOSTING)
+- [Step by step installation guide](https://github.com/paulov-t/SIT.Core/wiki/Step-By-Step-Installation-Guide) by [jeremymouton](https://github.com/jeremymouton)

--- a/wiki/en/Guides/HOSTING.md
+++ b/wiki/en/Guides/HOSTING.md
@@ -1,7 +1,7 @@
 ﻿# HOSTING
 
 ## How to allow others to join your SPT-Aki Server?
-* Follow [SETUP-STANDARD](SETUP-STANDARD) or [SETUP-HAMACHI](SETUP-HAMACHI)
+* Follow [SETUP-STANDARD](https://github.com/paulov-t/SIT.Core/wiki/SETUP-STANDARD) or [SETUP-HAMACHI](https://github.com/paulov-t/SIT.Core/wiki/SETUP-HAMACHI)
 
 ## How to join each other's match
 THIS IS EXTREMELY EXPERIMENTAL AT THIS TIME AND LIKELY TO CHANGE

--- a/wiki/en/Guides/Step-By-Step-Installation-Guide.md
+++ b/wiki/en/Guides/Step-By-Step-Installation-Guide.md
@@ -104,4 +104,4 @@ Launch the game via the `SIT Launcher`.
 
 ## 3. Create a Lobby
 
-See [How to join each other's match](https://github.com/paulov-t/SIT.Core/wiki/en/Guides/HOSTING.md#how-to-join-each-others-match) for in-game instructions.
+See [How to join each other's match](https://github.com/paulov-t/SIT.Core/wiki/HOSTING.md#how-to-join-each-others-match) for in-game instructions.


### PR DESCRIPTION
Update wiki links to use absolute URLs, as GitHub does not support relative pathing (https://github.com/orgs/community/discussions/14020)