### PR TITLE
Added sprinting replication and movement interpolation

### DIFF
--- a/Coop/Components/PlayerReplicatedComponent.cs
+++ b/Coop/Components/PlayerReplicatedComponent.cs
@@ -101,9 +101,26 @@ namespace SIT.Coop.Core.Player
                 bool prone = bool.Parse(packet["prn"].ToString());
                 if(prone)
                     player.MovementContext.SetProneStateForce();
+                // Sprint
+                bool sprint = bool.Parse(packet["spr"].ToString());
+                if (player.IsSprintEnabled)
+                {
+                    if (!sprint)
+                    {
+                        player.MovementContext.EnableSprint(false);
+                    }
+                }
+                else
+                {
+                    if (sprint)
+                    {
+                        player.MovementContext.EnableSprint(true);
+                    }
+                }
                 // Speed
                 float speed = float.Parse(packet["spd"].ToString());
-                player.MovementContext.CharacterMovementSpeed = speed;
+                player.CurrentState.ChangeSpeed(speed);
+                //player.MovementContext.CharacterMovementSpeed = speed;
                 // Rotation
                 Vector2 packetRotation = new Vector2(
                 float.Parse(packet["rX"].ToString())

--- a/Coop/Player/Player_Move_Patch.cs
+++ b/Coop/Player/Player_Move_Patch.cs
@@ -111,9 +111,24 @@ namespace SIT.Core.Coop.Player
                 {
                     UnityEngine.Vector2 direction = new UnityEngine.Vector2(float.Parse(dict["dX"].ToString()), float.Parse(dict["dY"].ToString()));
                     float spd = float.Parse(dict["spd"].ToString());
+                    bool spr = bool.Parse(dict["spr"].ToString());
                     playerReplicatedComponent.ReplicatedDirection = null;
                     playerReplicatedComponent.ReplicatedPosition = null;
                     player.MovementContext.CharacterMovementSpeed = spd;
+                    if (player.IsSprintEnabled) 
+                    {
+                        if (!spr)
+                        {
+                            player.MovementContext.EnableSprint(false);
+                        }
+                    } else
+                    {
+                        if (spr)
+                        {
+                            player.MovementContext.EnableSprint(true);
+                        }
+                    }
+                    player.CurrentState.ChangeSpeed(spd);
                     player.CurrentState.Move(direction);
                     player.InputDirection = direction;
                 }


### PR DESCRIPTION
[![trololo](https://img.youtube.com/vi/VahbLUiSZdY/0.jpg)](https://www.youtube.com/watch?v=VahbLUiSZdY)

This view is from the client-side, the server doesn't see clients as smoothly but I included the somewhat working code for that.
There WILL be cases where players stop sprinting and teleport to the next move packet because they are still running on their end. I guess spawned pmc's initially have the endurance skill at lvl1 and would need to be set to their profile's correct skill values after spawn to resolve this?

Bots on the other hand seem to be working perfectly fine and should make for a waaay smother gameplay on clients