### PR TITLE
Fix issues with semi-auto fire when tracking targets

### DIFF
--- a/Coop/Player/FirearmControllerPatches/FirearmController_SetTriggerPressed_Patch.cs
+++ b/Coop/Player/FirearmControllerPatches/FirearmController_SetTriggerPressed_Patch.cs
@@ -145,7 +145,7 @@ namespace SIT.Core.Coop.Player.FirearmControllerPatches
                     {
                         firearmCont.SetTriggerPressed(pressed);
                         //if (pressed && dict.ContainsKey("rX"))
-                        if (pressed && tpp.rX != 0)
+                        if (prc.IsClientDrone && pressed && tpp.rX != 0)
                         {
                             var rotat = new Vector2(tpp.rX, tpp.rY);
                             player.Rotation = rotat;


### PR DESCRIPTION
See https://github.com/paulov-t/SIT.Core/issues/217#issuecomment-1612361515 for details on the issue. TL;DR is that each time a player would shoot while actively moving the mouse, their aim would reset/shift slightly due to the changed code resetting their rotation. This is now only applied to ClientDrones, is I believe was the original intent (seems like an oversight and is just missing the condition check, correct me if I'm wrong!)