### PR TITLE
Drastically improved player client performance

### DIFF
--- a/Coop/Components/CoopGameComponent.cs
+++ b/Coop/Components/CoopGameComponent.cs
@@ -862,6 +862,18 @@ namespace SIT.Core.Coop
 
         private void CreateLocalPlayer(Profile profile, Vector3 position, int playerId)
         {
+            // If this is an actual PLAYER player that we're creating a drone for, when we set
+            // aiControl to true then they'll automatically run voice lines (eg when throwing
+            // a grenade) so we need to make sure it's set to FALSE for the drone version of them.
+            var useAiControl = !profile.Id.StartsWith("pmc");
+
+            // For actual bots, we can gain SIGNIFICANT clientside performance on the
+            // non-host client by ENABLING aiControl for the bot. This has zero consequences
+            // in terms of synchronization. No idea why having aiControl OFF is so expensive,
+            // perhaps it's more accurate to think of it as an inverse bool of
+            // "player controlled", where the engine has to enable a bunch of additional
+            // logic when aiControl is turned off (in other words, for players)?
+
             var otherPlayer = LocalPlayer.Create(playerId
                , position
                , Quaternion.identity
@@ -870,7 +882,7 @@ namespace SIT.Core.Coop
                ""
                , EPointOfView.ThirdPerson
                , profile
-               , aiControl: false
+               , aiControl: useAiControl
                , EUpdateQueue.Update
                , EFT.Player.EUpdateMode.Auto
                , EFT.Player.EUpdateMode.Auto


### PR DESCRIPTION
`aiControl` arg for the `EFT.LocalPlayer.Create` method has an outsized impact on performance when set to `false`. This fix makes it so that a value of `true` is passed into this method for bot drones. Why this change has such a huge positive impact on performance is not entirely clear, though I suspect that telling the game that `aiControl` should be false is somehow indicating that the `LocalPlayer` is a player player and not a bot, and that there's somehow a ton more overhead for player players as compared to bot players.

We've tested during a couple different raids and have encountered zero replication/sync issues whatsoever. Client FPS on Reserve before was in the low 10s, same players same AI count after implementing this change was 40+, variable based on how good the client's machine is.