### PR TITLE
Fixed headshots not instantly killing AI, closes https://github.com/paulov-t/SIT.Core/issues/232

### DIFF
--- a/Coop/Player/Player_ApplyDamageInfo_Patch.cs
+++ b/Coop/Player/Player_ApplyDamageInfo_Patch.cs
@@ -32,9 +32,9 @@ namespace SIT.Core.Coop.Player
             , ref DamageInfo damageInfo
             , EBodyPart bodyPartType)
         {
-            var result = false;
-            if (CallLocally.TryGetValue(__instance.Profile.AccountId, out var expecting) && expecting)
-                result = true;
+            var result = true;
+            if (CallLocally.TryGetValue(__instance.Profile.AccountId, out var expecting) && !expecting)
+                result = false;
 
             if (!LastDamageTypes.ContainsKey(__instance.ProfileId))
                 LastDamageTypes.Add(__instance.ProfileId, EDamageType.Undefined);

--- a/Coop/Player/Player_ApplyShot_Patch.cs
+++ b/Coop/Player/Player_ApplyShot_Patch.cs
@@ -27,9 +27,9 @@ namespace SIT.Core.Coop.Player
         [PatchPrefix]
         public static bool PrePatch(EFT.Player __instance)
         {
-            var result = false;
-            if (CallLocally.TryGetValue(__instance.Profile.AccountId, out var expecting) && expecting)
-                result = true;
+            var result = true;
+            if (CallLocally.TryGetValue(__instance.Profile.AccountId, out var expecting) && !expecting)
+                result = false;
 
             return result;
         }


### PR DESCRIPTION
The issue was that when you shot an AI for the first time, they wouldn't be listed in the `CallLocally` dict. When this is the case, the following condition `(CallLocally.TryGetValue(__instance.Profile.AccountId, out var expecting) && expecting)` breaks down as follows:

- `(CallLocally.TryGetValue(__instance.Profile.AccountId, out var expecting)`, the `TryGetValue` method returns `false` here because the key doesn't exist in the dictionary.

The issue is that because `return` is `false`, and it isn't set to `true`, the PrePatch effectively cancels the engine's handling of the damage event (as far as I understand the patching system, which is _not very well!_). So the end result is this: first time you shoot an AI, it doesn't register. You have to shoot them a second time for something to happen, because at that point they've been added to the `CallLocally` dictionary by the various other method calls.