### PR TITLE
Fixed underlying issue causing headshots to break

### DIFF
--- a/Coop/Player/Player_ApplyDamageInfo_Patch.cs
+++ b/Coop/Player/Player_ApplyDamageInfo_Patch.cs
@@ -32,10 +32,10 @@ namespace SIT.Core.Coop.Player
             , ref DamageInfo damageInfo
             , EBodyPart bodyPartType)
         {
-            var result = true;
-            if (CallLocally.TryGetValue(__instance.Profile.AccountId, out var expecting) && !expecting)
-                result = false;
 
+            var result = false;
+            if (CallLocally.TryGetValue(__instance.Profile.AccountId, out var expecting) && expecting)
+                result = true;
             if (!LastDamageTypes.ContainsKey(__instance.ProfileId))
                 LastDamageTypes.Add(__instance.ProfileId, EDamageType.Undefined);
 
@@ -94,6 +94,7 @@ namespace SIT.Core.Coop.Player
 
 
             Dictionary<string, object> packet = new();
+            var bodyPartColliderType = ((BodyPartCollider)damageInfo.HittedBallisticCollider).BodyPartColliderType;
             damageInfo.HitCollider = null;
             damageInfo.HittedBallisticCollider = null;
             Dictionary<string, string> playerDict = new();
@@ -124,6 +125,7 @@ namespace SIT.Core.Coop.Player
             packet.Add("d.p", playerDict);
             packet.Add("d.w", weaponDict);
             packet.Add("bpt", bodyPartType.ToString());
+            packet.Add("bpct", bodyPartColliderType.ToString());
             packet.Add("ab", absorbed.ToString());
             packet.Add("hs", headSegment.ToString());
             packet.Add("m", "ApplyDamageInfo");
@@ -168,10 +170,13 @@ namespace SIT.Core.Coop.Player
             try
             {
                 Enum.TryParse<EBodyPart>(dict["bpt"].ToString(), out var bodyPartType);
+                Enum.TryParse<EBodyPartColliderType>(dict["bpct"].ToString(), out var bodyPartColliderType);
                 Enum.TryParse<EHeadSegment>(dict["hs"].ToString(), out var headSegment);
                 var absorbed = float.Parse(dict["ab"].ToString());
 
                 var damageInfo = Player_ApplyShot_Patch.BuildDamageInfoFromPacket(dict);
+                damageInfo.HittedBallisticCollider = Player_ApplyShot_Patch.GetBodyPartCollider(player, bodyPartColliderType);
+                damageInfo.HitCollider = Player_ApplyShot_Patch.GetCollider(player, bodyPartColliderType);
 
                 CallLocally.Add(player.Profile.AccountId, true);
                 player.ApplyDamageInfo(damageInfo, bodyPartType, absorbed, headSegment);


### PR DESCRIPTION
This commit reverts the previous changes I made in https://github.com/paulov-t/SIT.Core/pull/310 and fixes the actual underlying issue that was causing headshots to break. The `Replicated()` method's call to `EFT.Player.ApplyShot()` was actually throwing a null object error, but doing so silently because the exception code wasn't catching it. This made me think the issue was something else with my previous PR, which _did_ technically fix the headshots, but it also completely mangled damage replication in the process. Damage was multiplied by a large factor due to my original changes.

Instead of slapping a bandaid on the issue that _looked_ like a real solution to me at the time, this PR actually fixes the underlying null object references that cause the replicated `ApplyShot()` to fail to run. We pull the `HittedBallisticCollider` from the original `DamageInfo` that kicks things off, cast it to the actual data type (`BodyPartCollider`), and grab the `BodyPartColliderType` field from it. We then pass the `BodyPartColliderType` through the packet to be replicated later. When it's time for replication to occur, we grab a valid, non-null value for the `DamageInfo.HitCollider` and `DamageInfo.HittedBallisticCollider` fields for the target `player` via the new `GetBodyPartCollider` and `GetCollider` methods. These methods find which `_hitCollider` on the `player` object is the correct one to apply the damage to.


References:

- My original `headshot_fix` PR that broke shit: https://github.com/paulov-t/SIT.Core/pull/310
- Discussion re. the damage replication bug: https://github.com/paulov-t/SIT.Core/discussions/313#discussioncomment-6454719