### PR TITLE
Refactored client ping calculation to use round-trip time

### DIFF
--- a/Coop/Components/CoopGameComponent.cs
+++ b/Coop/Components/CoopGameComponent.cs
@@ -34,6 +34,7 @@ namespace SIT.Core.Coop
         private AkiBackendCommunication RequestingObj { get; set; }
         public SITConfig SITConfig { get; private set; }
         public string ServerId { get; set; } = null;
+        public string AccountId { get; set; } = null;
         public Dictionary<string, EFT.Player> Players { get; private set; } = new();
         public EFT.Player[] PlayerUsers
         {
@@ -132,7 +133,10 @@ namespace SIT.Core.Coop
             // ----------------------------------------------------
             // Always clear "Players" when creating a new CoopGameComponent
             Players = new Dictionary<string, EFT.Player>();
+
             var ownPlayer = (LocalPlayer)Singleton<GameWorld>.Instance.RegisteredPlayers.First(x => x.IsYourPlayer);
+            AccountId = ownPlayer.Profile.AccountId;
+
             Players.Add(ownPlayer.Profile.AccountId, ownPlayer);
 
             //RequestingObj = AkiBackendCommunication.GetRequestInstance(true, Logger);
@@ -1198,7 +1202,6 @@ namespace SIT.Core.Coop
 
         public int ServerPing { get; set; } = 1;
         public ConcurrentQueue<int> ServerPingSmooth { get; } = new();
-        public TimeSpan LastServerPing { get; set; } = DateTime.Now.TimeOfDay;
 
         public bool HighPingMode { get; set; } = false;
         public bool ServerHasStopped { get; set; }

--- a/Core/AkiBackendCommunication.cs
+++ b/Core/AkiBackendCommunication.cs
@@ -18,6 +18,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
+using UnityEngine.Networking.Match;
 
 namespace SIT.Core.Core
 {
@@ -92,6 +93,7 @@ namespace SIT.Core.Core
                 RemoteEndPoint = PatchConstants.GetBackendUrl();
 
             GetHeaders();
+            PeriodicallySendPing();
             PeriodicallySendPooledData();
             if (WebSocket == null)
             {
@@ -167,15 +169,15 @@ namespace SIT.Core.Core
                 // coopGameComponent.ReadFromServerLastActionsParseData(packet);
                 // -------------------------------------------------------
 
-                // If this is a ping packet, resolve and create a smooth ping
-                if (packet.ContainsKey("ping"))
+                // If this is a pong packet, resolve and create a smooth ping
+                if (packet.ContainsKey("pong"))
                 {
                     //m_ManualLogSource.LogDebug(packet["ping"].ToString());
-                    var pingStrip = packet["ping"].ToString().Split(':');
-                    var timeStampOfPing = new TimeSpan(0, int.Parse(pingStrip[0]), int.Parse(pingStrip[1]), int.Parse(pingStrip[2]), int.Parse(pingStrip[3]));
-                    var serverPing = (timeStampOfPing - coopGameComponent.LastServerPing).Milliseconds;
-                    coopGameComponent.LastServerPing = timeStampOfPing;
-                    if (coopGameComponent.ServerPingSmooth.Count > 300)
+                    var pingStrip = ((DateTimeOffset)packet["pong"]).ToString("o");
+                    var timeStampOfPing = ParseIso8601Timestamp(pingStrip);
+                    var serverPing = (int)(DateTimeOffset.Now - timeStampOfPing).TotalMilliseconds;
+                    //Logger.LogDebug("Pong (" + pingStrip + ", " + timeStampOfPing + ", " + serverPing + ")");
+                    if (coopGameComponent.ServerPingSmooth.Count > 30)
                         coopGameComponent.ServerPingSmooth.TryDequeue(out _);
                     coopGameComponent.ServerPingSmooth.Enqueue(serverPing);
                     coopGameComponent.ServerPing = coopGameComponent.ServerPingSmooth.Count > 0 ? (int)Math.Round(coopGameComponent.ServerPingSmooth.Average()) : 1;
@@ -373,6 +375,40 @@ namespace SIT.Core.Core
                     PostPingSmooth.Enqueue((int)swPing.ElapsedMilliseconds - awaitPeriod);
                     PostPing = (int)Math.Round(PostPingSmooth.Average());
 
+                }
+            });
+        }
+
+        private Task PeriodicallySendPingTask;
+
+        private void PeriodicallySendPing()
+        {
+            PeriodicallySendPingTask = Task.Run(async () =>
+            {
+                int awaitPeriod = 2000;
+                while (true)
+                {
+                    await Task.Delay(awaitPeriod);
+
+                    if (WebSocket != null)
+                    {
+                        if (WebSocket.ReadyState == WebSocketSharp.WebSocketState.Open)
+                        {
+                            if (CoopGameComponent.TryGetCoopGameComponent(out var coopGameComponent))
+                            {
+                                PatchConstants.Logger.LogDebug($"WS:Ping Send");
+
+                                Dictionary<string, object> packet = new Dictionary<string, object> {
+                                    { "m", "Ping" },
+                                    { "t", DateTimeOffset.Now.ToString("o") },
+                                    { "accountId", coopGameComponent.AccountId },
+                                    { "serverId", coopGameComponent.ServerId }
+                                };
+
+                                PostJson("/coop/server/update", packet.ToJson());
+                            }
+                        }
+                    }
                 }
             });
         }
@@ -736,6 +772,22 @@ namespace SIT.Core.Core
         //        }
         //    }
         //}
+
+        public DateTimeOffset ParseIso8601Timestamp(string timestampString)
+        {
+            // Parse the timestamp string using the DateTimeOffset.TryParseExact method
+            // The format "o" represents the ISO 8601 format
+            if (DateTimeOffset.TryParseExact(timestampString, "o", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind, out DateTimeOffset parsedTimestamp))
+            {
+                return parsedTimestamp;
+            }
+            else
+            {
+                // If parsing fails, you can choose to throw an exception or return a default value
+                // We return DateTimeOffset.MinValue to indicate an error
+                return DateTimeOffset.MinValue;
+            }
+        }
 
         public void Dispose()
         {


### PR DESCRIPTION
This is a far more accurate method than what was being done before to calculate ping times.

Requires [SIT.Aki-Server-Mod](https://github.com/paulov-t/SIT.Aki-Server-Mod) update as ping messaging between the client and server had to change