### PR TITLE
Fixed grenade kill attribution

### DIFF
--- a/Coop/Player/Player_ApplyShot_Patch.cs
+++ b/Coop/Player/Player_ApplyShot_Patch.cs
@@ -193,6 +193,14 @@ namespace SIT.Core.Coop.Player
                             damageInfo.Weapon = w;
                         }
                     }
+                    else
+                    {
+                        var createdItem = Tarkov.Core.Spawners.ItemFactory.CreateItem(dict["d.w.id"].ToString(), dict["d.w.tpl"].ToString());
+                        if (createdItem is Weapon wep)
+                        {
+                            damageInfo.Weapon = wep;
+                        }
+                    }
                 //}
             }
 


### PR DESCRIPTION
When a grenade kills someone, the grenade object immediately ceases to exist. In order for the kill the be tracked as a grenade kill, we need to recreate a facsimile grenade object to use for the `damageInfo` weapon. We reuse the old GUID of the grenade object that doesn't exist anymore.