### PR TITLE
Fixed desync states where drones walk in place

### DIFF
--- a/Coop/Components/CoopGameComponent.cs
+++ b/Coop/Components/CoopGameComponent.cs
@@ -19,6 +19,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -1044,7 +1045,15 @@ namespace SIT.Core.Coop
             var registeredPlayers = Singleton<GameWorld>.Instance.RegisteredPlayers;
 
             if (!Players.Any(x => x.Key == accountId) && !registeredPlayers.Any(x => x.Profile.AccountId == accountId))
+            {
+                // Start a new thread that waits for the localplayer to exist to send death events about them
+                if (packet["m"].ToString() == "Kill")
+                {
+                    Logger.LogDebug($"{DateTime.Now.ToString("MM/dd/yyyy HH:mm:ss.fff")}: Received kill packet for null player with ID {accountId}, enqueuing death");
+                    Task.Run(() => WaitForPlayerAndProcessPacket(accountId, packet));
+                }
                 return;
+            }
 
             foreach (var plyr in
                 Players.ToArray()
@@ -1121,6 +1130,39 @@ namespace SIT.Core.Coop
                     }
                 }
                 catch (Exception) { }
+            }
+        }
+
+        private void WaitForPlayerAndProcessPacket(string accountId, Dictionary<string, object> packet)
+        {
+            // Start the timer.
+            var startTime = DateTime.Now;
+            var maxWaitTime = TimeSpan.FromMinutes(2);
+
+            while (true)
+            {
+                // Check if maximum wait time has been reached.
+                if (DateTime.Now - startTime > maxWaitTime)
+                {
+                    Logger.LogError($"{DateTime.Now.ToString("MM/dd/yyyy HH:mm:ss.fff")}: WaitForPlayerAndProcessPacket waited for {maxWaitTime.TotalMinutes} minutes, but player {accountId} still did not exist after timeout period.");
+                    return;
+                }
+
+                if (Players == null)
+                    continue;
+
+                var registeredPlayers = Singleton<GameWorld>.Instance.RegisteredPlayers;
+
+                // If the player now exists, process the packet and end the thread.
+                if (Players.Any(x => x.Key == accountId) || registeredPlayers.Any(x => x.Profile.AccountId == accountId))
+                {
+                    // Logger.LogDebug($"{DateTime.Now.ToString("MM/dd/yyyy HH:mm:ss.fff")}: WaitForPlayerAndProcessPacket waited for {(DateTime.Now - startTime).TotalSeconds}s");
+                    ProcessPlayerPacket(packet);
+                    return;
+                }
+
+                // Wait for a short period before checking again.
+                Thread.Sleep(1000);
             }
         }
 


### PR DESCRIPTION
There are currently two edge cases that can result in a drone walking in place instead of being dead:

- Player/bot dies very quickly after spawning. In this case, the remote drones don't have time to initialize before the `Kill` packet is received. `Kill` packet triggers logic looking for the remote drone, which it cannot find and then gives up. We add a thread that checks for the drone's existence every second for max two minutes and then gives up.
- Player/bot dies before a client is able to fully connect. In this case, the `Kill` packet for the drone is never received in the first place. The connecting client gets a list of players to create drones for, and will dutifully create a drone that corresponds to the now-dead player/bot. This player/bot drone will subsequently walk in place where they spawn. We fix this by hooking into the `Kill` packet and updating the character data sent to JIPing clients to flag dead units, and then leverage that flag in the clientside drone creation code to kill units that should be dead after they've spawned into the game world.


This relies upon changes made in https://github.com/paulov-t/SIT.Aki-Server-Mod/pull/4