### PR TITLE
Add Linux hosting guide to wiki

### DIFF
--- a/wiki/cn/Guides/Linux开服教程.md
+++ b/wiki/cn/Guides/Linux开服教程.md
@@ -1,0 +1,22 @@
+# 如何在Linux上运行服务器
+### 步骤 1 从源代码编译Aki服务器
+详见 SPT-Aki 服务器仓库中的说明 [Server](https://dev.sp-tarkov.com/SPT-AKI/Server)。 大致操作:
+```bash
+git clone https://dev.sp-tarkov.com/SPT-AKI/Server.git
+cd Server/project
+git fetch
+# 如果需要切换至其他分支, 比如 0.13.5.0
+# git checkout 0.13.5.0
+git lfs fetch
+git lfs pull
+npm install
+npm run build:release # 或者 build:debug
+# 服务器会被编译进 ./build 文件夹
+```
+**一定要把编译好的服务器移动或者复制到别的位置！ 不要直接从编译文件夹运行服务器！编译文件夹会在每次编译中删除并重建！**
+
+### 步骤 2 安装SIT的服务器Mod
+从这里开始，就和在Windows上开服操作一致了:
+- 下载并安装最新的服务器Mod
+- 如有需要更改服务器设置文件
+- 通过 `/path/to/Aki.Server.exe` 运行服务器

--- a/wiki/cn/部署教程-Guides.md
+++ b/wiki/cn/部署教程-Guides.md
@@ -4,3 +4,4 @@
 - [使用HAMACH架设服务器](../en/Guides/SETUP-HAMACHI.md) 源于 [ppyLEK](https://github.com/ppyLEK) （在国内不常使用该方法，故使用英文原文）
 - [游戏内建立房间/加入房间](./Guides/HOSTING.md)
 - [详细建设服务器方法](./Guides/Step-By-Step-Installation-Guide.md) 源于 [jeremymouton](https://github.com/jeremymouton)
+- [如何在Linux上运行服务器](./Guides/Linux开服教程.md)

--- a/wiki/en/FAQs-English.md
+++ b/wiki/en/FAQs-English.md
@@ -53,7 +53,3 @@ __Set useExternalIPFinder to false__
 __Now you are good to go. Have some fun~__
 
 ---
-
-### Using the SPT-Aki Server in Linux
-
-If you are using the SPT-Aki server with the mod attached in Linux, please refer to [this issue](https://github.com/paulov-t/SIT.Core/issues/132) for more information on how to fix problems if they arise

--- a/wiki/en/Guides-English.md
+++ b/wiki/en/Guides-English.md
@@ -4,3 +4,4 @@ Useful Guides:
 - [SETUP-HAMACHI](https://github.com/paulov-t/SIT.Core/wiki/Setup-Hamachi-English) by [ppyLEK](https://github.com/ppyLEK)
 - [HOSTING](https://github.com/paulov-t/SIT.Core/wiki/Hosting-English)
 - [Step by step installation guide](https://github.com/paulov-t/SIT.Core/wiki/Step-By-Step-Installation-Guide-English) by [jeremymouton](https://github.com/jeremymouton)
+- [Using the SPT-Aki Server in Linux](./Guides/Run-Server-on-Linux-English.md)

--- a/wiki/en/Guides/Run-Server-on-Linux-English.md
+++ b/wiki/en/Guides/Run-Server-on-Linux-English.md
@@ -1,0 +1,23 @@
+# Using the SPT-Aki Server in Linux
+
+### Step 1 Build the Server
+Follow the readme on SPT-Aki's [Server](https://dev.sp-tarkov.com/SPT-AKI/Server) repo. Generally:
+```bash
+git clone https://dev.sp-tarkov.com/SPT-AKI/Server.git
+cd Server/project
+git fetch
+# If you need to switch to a different branch, for example, 0.13.5.0
+# git checkout 0.13.5.0
+git lfs fetch
+git lfs pull
+npm install
+npm run build:release # or build:debug
+# The server will be built in ./build
+```
+**Copy or move the server build to somewhere else! DON'T run the server directly from the build directory! The build directory will be deleted and recreated again during a build.**
+
+### Step 2 Install the SIT Server Mod
+From here on, it is basically the same as hosting on Windows:
+- Download and install the latest server mod
+- Change the config files if needed
+- Run the server by `/path/to/Aki.Server.exe`

--- a/wiki/ja/FAQs-Japanese.md
+++ b/wiki/ja/FAQs-Japanese.md
@@ -56,4 +56,4 @@ __以上です。あとは楽しめることですね！__
 
 ### LinuxでSPT-Akiをご利用する方へ
 
-Linuxを利用中にこのMODを使用する時、問題が発生すると[この問題](https://github.com/paulov-t/SIT.Core/issues/132)を参考してください。
+[The English Version](../en/Guides/Run-Server-on-Linux-English.md)

--- a/wiki/po/FAQs-Portuguese.md
+++ b/wiki/po/FAQs-Portuguese.md
@@ -56,5 +56,4 @@ __Agora você está pronto para começar. Divirta-se!__
 ---
 
 ### Usando o Servidor SPT-Aki no Linux
-
-Se você estiver usando o servidor SPT-Aki com o mod anexado no Linux, consulte [este problema](https://github.com/paulov-t/SIT.Core/issues/132) para obter mais informações sobre como corrigir problemas, caso ocorram.
+[The English Version](../en/Guides/Run-Server-on-Linux-English.md)


### PR DESCRIPTION
I fixed the mod loading issue on Linux in [this](https://dev.sp-tarkov.com/SPT-AKI/Server/pulls/132) Aki server pr. Now, the Linux server can load mods without import errors.

Hence, I updated the wiki with a simple guide on Linux server hosting.

Keep in mind, currently, the fix is only in the [0.13.5.0](https://dev.sp-tarkov.com/SPT-AKI/Server/src/branch/0.13.5.0) branch of aki server, not yet been merged into master.