### PR TITLE
Enable or Disable HTTPS patches

### DIFF
--- a/Source/StayInTarkovPlugin.cs
+++ b/Source/StayInTarkovPlugin.cs
@@ -27,6 +27,7 @@ using SIT.Core.SP.PlayerPatches.Health;
 using SIT.Core.SP.Raid;
 using SIT.Core.SP.ScavMode;
 using SIT.Tarkov.Core;
+using SIT.Tarkov.Core.Web;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -214,9 +215,15 @@ namespace SIT.Core
                 // Web Requests
                 new SslCertificatePatch().Enable();
                 new UnityWebRequestPatch().Enable();
-                new TransportPrefixPatch().Enable();
-                new WebSocketPatch().Enable();
                 new SendCommandsPatch().Enable();
+
+                //https to http | wss to ws
+                var url = BackendConnection.GetBackendConnection().BackendUrl;
+                if (!url.Contains("https"))
+                {
+                    new TransportPrefixPatch().Enable();
+                    new WebSocketPatch().Enable();
+                }
 
                 //new TarkovTransportHttpMethodDebugPatch2().Enable();
             }


### PR DESCRIPTION
Use https to disable them
Use http to enable them
(CONFIG ARGUMENT!)

This help users or even advanced guys , like me. To can make his server based on HTTPS or just HTTP without care about SIT using the wrong one.
This still doesnt care about your certificate as this stuff patched before it.