### PR TITLE
Improve left hand animation when interacting with door, and many bug fixes

### DIFF
--- a/Source/Coop/Components/SITMatchmakerGUIComponent.cs
+++ b/Source/Coop/Components/SITMatchmakerGUIComponent.cs
@@ -199,6 +199,7 @@ namespace SIT.Core.Coop.Components
                 buttonX += buttonWidth + 10;
                 if (GUI.Button(new UnityEngine.Rect(buttonX, buttonY, buttonWidth, buttonHeight), StayInTarkovPlugin.LanguageDictionary["PLAY_SINGLE_PLAYER"], gamemodeButtonStyle))
                 {
+                    FixesHideoutMusclePain();
                     MatchmakerAcceptPatches.MatchingType = EMatchmakerType.Single;
                     OriginalAcceptButton.OnClick.Invoke();
                     DestroyThis();
@@ -454,6 +455,7 @@ namespace SIT.Core.Coop.Components
 
                 AkiBackendCommunication.Instance.WebSocketCreate(MatchmakerAcceptPatches.Profile);
 
+                FixesHideoutMusclePain();
                 DestroyThis();
                 OriginalAcceptButton.OnClick.Invoke();
             }
@@ -578,13 +580,39 @@ namespace SIT.Core.Coop.Components
             {
                 AkiBackendCommunication.Instance.WebSocketCreate(MatchmakerAcceptPatches.Profile);
 
+                FixesHideoutMusclePain();
                 MatchmakerAcceptPatches.CreateMatch(MatchmakerAcceptPatches.Profile.ProfileId, RaidSettings);
                 OriginalAcceptButton.OnClick.Invoke();
                 DestroyThis();
             }
         }
 
-        
+        void FixesHideoutMusclePain()
+        {
+            // Check if hideout world exists
+            var world = Comfort.Common.Singleton<GameWorld>.Instance;
+            if (world == null)
+                return;
+
+            foreach (EFT.Player player in world.RegisteredPlayers)
+            {
+                // There should be 1 player only, but well, who knows if some bugs remain...
+                if (player.IsYourPlayer)
+                {
+                    HealthController.MusclePain musclePain = player.HealthController.FindActiveEffect<HealthController.MusclePain>(EBodyPart.Common);
+                    if (musclePain != null)
+                    {
+                        musclePain.Remove();
+                    }
+                    HealthController.SevereMusclePain severeMusclePain = player.HealthController.FindActiveEffect<HealthController.SevereMusclePain>(EBodyPart.Common);
+                    if (severeMusclePain != null)
+                    {
+                        severeMusclePain.Remove();
+                    }
+                    break;
+                }
+            }
+        }
 
         void DestroyThis()
         {

--- a/Source/Coop/CoopGame.cs
+++ b/Source/Coop/CoopGame.cs
@@ -461,6 +461,28 @@ namespace SIT.Core.Coop
                     this.Bots.Add(localPlayer.ProfileId, localPlayer);
                 }
 
+                // Start with SPT-AKI 3.7.0 AI PMC carrying 'FiR' items, this is just a simple "concept" of it.
+                // Every AI PMC who have backpack, their items in the backpack are 'FiR'.
+                if (profile.Info.Side == EPlayerSide.Bear || profile.Info.Side == EPlayerSide.Usec)
+                {
+                    var backpackSlot = profile.Inventory.Equipment.GetSlot(EFT.InventoryLogic.EquipmentSlot.Backpack);
+                    var backpack = backpackSlot.ContainedItem;
+                    if (backpack != null)
+                    {
+                        EFT.InventoryLogic.Item[] items = backpack.GetAllItems()?.ToArray();
+                        if (items != null)
+                        {
+                            for (int i = 0; i < items.Count(); i++)
+                            {
+                                EFT.InventoryLogic.Item item = items[i];
+                                if (item == backpack)
+                                    continue;
+
+                                item.SpawnedInSession = true;
+                            }
+                        }
+                    }
+                }
 
                 //GCHelpers.EnableGC();
                 ////GCHelpers.Collect(true);

--- a/Source/Coop/Player/Health/RestoreBodyPartPatch.cs
+++ b/Source/Coop/Player/Health/RestoreBodyPartPatch.cs
@@ -84,23 +84,22 @@ namespace SIT.Core.Coop.Player.Health
                 //Logger.LogInfo(dict.ToJson());
 
                 var bodyPart = (EBodyPart)Enum.Parse(typeof(EBodyPart), restoreBodyPartPacket.BodyPart, true);
-                var bodyPartDict = GetBodyPartDictionary(player);
+                var bodyPartState = GetBodyPartDictionary(player)[bodyPart];
 
-
-                var state = bodyPartDict[bodyPart];
-                if (state == null)
+                if (bodyPartState == null)
                 {
                     Logger.LogError($"Could not retreive {player.ProfileId}'s Health State for Body Part {restoreBodyPartPacket.BodyPart}");
                     return;
                 }
-                bodyPartDict[bodyPart].IsDestroyed = false;
-                var healthPenalty = restoreBodyPartPacket.HealthPenalty + (1f - restoreBodyPartPacket.HealthPenalty) * (float)player.Skills.SurgeryReducePenalty;
-                Logger.LogDebug("RestoreBodyPart::HealthPenalty::" + healthPenalty);
-                bodyPartDict[bodyPart].Health
-                    = new HealthValue(1f, Mathf.Max(1f, Mathf.Ceil(bodyPartDict[bodyPart].Health.Maximum * healthPenalty)), 0f);
+
+                if (bodyPartState.IsDestroyed)
+                {
+                    bodyPartState.IsDestroyed = false;
+                    var healthPenalty = restoreBodyPartPacket.HealthPenalty + (1f - restoreBodyPartPacket.HealthPenalty) * player.Skills.SurgeryReducePenalty;
+                    Logger.LogDebug("RestoreBodyPart::HealthPenalty::" + healthPenalty);
+                    bodyPartState.Health = new HealthValue(1f, Mathf.Max(1f, Mathf.Ceil(bodyPartState.Health.Maximum * healthPenalty)), 0f);
+                }
             }
-
-
         }
 
         private Dictionary<EBodyPart, BodyPartState> GetBodyPartDictionary(EFT.Player player)

--- a/Source/Coop/Player/Player_ApplyShot_Patch.cs
+++ b/Source/Coop/Player/Player_ApplyShot_Patch.cs
@@ -164,21 +164,22 @@ namespace SIT.Core.Coop.Player
                 }
             }
 
-            if (dict.ContainsKey("d.w.id"))
+            if (dict.ContainsKey("d.w.id") && dict.ContainsKey("d.w.tpl"))
             {
-                if (ItemFinder.TryFindItem(dict["d.w.id"].ToString(), out Item item))
+                string itemId = dict["d.w.id"].ToString();
+                string templateId = dict["d.w.tpl"].ToString();
+
+                if (ItemFinder.TryFindItem(itemId, out Item item))
                 {
-                    if (item is Weapon w)
-                    {
-                        damageInfo.Weapon = w;
-                    }
+                    damageInfo.Weapon = item;
                 }
                 else
                 {
-                    var createdItem = Tarkov.Core.Spawners.ItemFactory.CreateItem(dict["d.w.id"].ToString(), dict["d.w.tpl"].ToString());
-                    if (createdItem is Weapon wep)
+                    // Grenade is disposed after explode, so we need to create a template item for DamageInfo, to fixes "Unknown weapon" killing
+                    var createdItem = Tarkov.Core.Spawners.ItemFactory.CreateItem(itemId, templateId);
+                    if (createdItem != null)
                     {
-                        damageInfo.Weapon = wep;
+                        damageInfo.Weapon = createdItem;
                     }
                 }
             }

--- a/Source/SP/Menus/OfflineSettingsScreenPatch.cs
+++ b/Source/SP/Menus/OfflineSettingsScreenPatch.cs
@@ -65,11 +65,11 @@ namespace SIT.Core.SP.Menus
             )
         {
             var warningPanel = GameObject.Find("WarningPanelHorLayout");
-            warningPanel.active = false;
+            warningPanel?.SetActive(false);
             var settingslayoutcon = GameObject.Find("NonLayoutContainer");
-            settingslayoutcon.active = false;
+            settingslayoutcon?.SetActive(false);
             var settingslist = GameObject.Find("RaidSettingsSummary");
-            settingslist.active = false;
+            settingslist?.SetActive(false);
             RemoveBlockers(__instance
              , profileInfo
              , raidSettings
@@ -80,7 +80,7 @@ namespace SIT.Core.SP.Menus
              , ____nextButtonSpawner
              );
 
-            ____changeSettingsButton.OnPointerClick(new UnityEngine.EventSystems.PointerEventData(null) { });
+            ____changeSettingsButton?.OnPointerClick(new UnityEngine.EventSystems.PointerEventData(null) { });
 
             //Logger.LogInfo("AutoSetOfflineMatch2.Postfix");
 

--- a/Source/SP/PlayerPatches/Health/HealthListener.cs
+++ b/Source/SP/PlayerPatches/Health/HealthListener.cs
@@ -66,6 +66,12 @@ namespace SIT.Core.SP.PlayerPatches.Health
 
         public void Update(object healthController, bool inRaid)
         {
+            if (healthController == null)
+            {
+                PatchConstants.Logger.LogInfo("HealthListener.Update: HealthController is NULL");
+                return;
+            }
+
             PatchConstants.Logger.LogDebug("HealthListener.Update and Sync.");
 
             MyHealthController = healthController;

--- a/Source/SP/Raid/UpdateDogtagPatch.cs
+++ b/Source/SP/Raid/UpdateDogtagPatch.cs
@@ -54,6 +54,8 @@ namespace SIT.Core.SP.Raid
             if (dogTagComponent == null)
                 return;
 
+            dogtagItem.SpawnedInSession = true;
+
             var victimProfileInfo = __instance.Profile.Info;
 
             dogTagComponent.AccountId = __instance.Profile.AccountId;
@@ -62,7 +64,7 @@ namespace SIT.Core.SP.Raid
             dogTagComponent.Side = victimProfileInfo.Side;
             dogTagComponent.KillerName = aggressor.Profile.Info.Nickname;
             dogTagComponent.Time = DateTime.Now;
-            dogTagComponent.Status = "Killed by ";
+            dogTagComponent.Status = "Killed by";
             dogTagComponent.KillerAccountId = aggressor.Profile.AccountId;
             dogTagComponent.KillerProfileId = aggressor.Profile.Id;
 


### PR DESCRIPTION
Improve(s):
- When other player interacting with door, the left hand animation are now working as in Live. <details>
  <summary>Known bug</summary>
  Breaching door are still NOT fixed, only 'Unlock', 'Open' and 'Close' are improved.
  
  (Breach function are now shifted to KickOpen(Vector3, bool), I'm still looking to how to hook the event)
</details>

- AI PMC now have their dogtag and items in the backpack have "Found in Raid" mark, since SPT-AKI doing the same thing start with 3.7.0.

Fix(s):
- If you killed enemy with your knife or a grenade, in the kill list it's showing "Unknown weapon". As a bonus, you can normally exp your "Melee" skill now.
- in the AI PMC's dogtag, the kill status are showing English "Killed by *" even you are using other language.
- Open settings menu in coop raid will cause error that won't shown in BepInEx log.
- After done the QTE in hideout gym, join or create any game (coop/sp) will cause error.
- Second time entering offline settings menu will cause error that won't shown in BepInEx log, and player will be available to see the settings menu but locked.
- Using CMS/Surv12 for just 'Cure fracture' will make the body part that you are trying to cure change it's health to 1 even it's not broken.<details>
  <summary>Known bug</summary>
  Exping "Surgery" skill by using these are NOT fixed, I'm still investigating to it.
</details>

Other bug fixes are also coming, but it's not perfect or not tested with many times, so now, that's all.
Some of commits are not just made by me, it's made by my friend, but I have asked him and he don't mind if I use his code to contribute.

<details><summary>See other bugs we are currently investigating / fixing / testing:</summary>

  1. As mentioned above, breach door are not sync and "Surgery" skill will not increase in coop raid (works normally in sp raid).

  2. Extracted player can be killed or died due to any reason, and when he dies, the next player extracts immediately.

  3. Droping item that has discard limit will cause error, and there is no any "confirm the discard" dialog before you do it.

  4. Cannot switch the NVG, Thermal or Mask Shield on the helmet. The mod installed on helmet are not sync when switching.

  5. Clients don't have screen stun effect when receiving damage by gun shot.

  6. Player PMC are not having dogtag.

  7. Cannot see other player droping their item, even the code is running 100% fine (BSG's fault)

  8. Game randomly desync the inventory between players, making the missions that require placing "MS2000" to mark location impossible to complete.

  99 . Our current ultimate goal is make a full synced airdrop :D
</details>