### PR TITLE
Fixes door interact patch not sending profile id

### DIFF
--- a/Source/Coop/World/Door_Interact_Patch.cs
+++ b/Source/Coop/World/Door_Interact_Patch.cs
@@ -135,11 +135,12 @@ namespace SIT.Core.Coop.World
                 { "t", DateTime.Now.Ticks.ToString("G") },
                 { "serverId", CoopGameComponent.GetServerId() },
                 { "doorId", __instance.Id },
+                { "player", __instance.InteractingPlayer.ProfileId },
                 { "type", interactionResult.InteractionType.ToString() },
                 { "m", MethodName }
             };
 
-            var packetJson = packet.SITToJson();
+            //var packetJson = packet.SITToJson();
             //Logger.LogDebug(packetJson);
 
             //Request.Instance.PostJsonAndForgetAsync("/coop/server/update", packetJson);


### PR DESCRIPTION
I have forgot to make https://github.com/paulov-t/SIT.Core/commit/88b232e709a901e1e224b2d8d61194ee04af7caf send the packet that contain player profile id, which make this feature useless.