### PR TITLE
fix unknown compression method on profile save after raid extract

### DIFF
--- a/Source/Core/AkiBackendCommunication.cs
+++ b/Source/Core/AkiBackendCommunication.cs
@@ -696,8 +696,8 @@ namespace SIT.Core.Core
 
                 // set request body
                 var inputDataBytes = Encoding.UTF8.GetBytes(data);
-                //byte[] bytes = compress ? Zlib.Compress(inputDataBytes, ZlibCompression.Fastest) : inputDataBytes;
-                byte[] bytes = compress ? Zlib.Compress(data) : inputDataBytes;
+                byte[] bytes = compress ? Zlib.Compress(inputDataBytes, ZlibCompression.Fastest) : inputDataBytes;
+                //byte[] bytes = compress ? Zlib.Compress(data) : inputDataBytes;
                 data = null;
                 request.ContentType = "application/json";
                 request.ContentLength = bytes.Length;

--- a/Source/Misc/Zlib.cs
+++ b/Source/Misc/Zlib.cs
@@ -64,7 +64,8 @@ namespace SIT.Core.Misc
         /// </summary>
         public static byte[] Compress(byte[] data, ZlibCompression level)
         {
-            byte[] buffer = new byte[data.Length + 24];
+            // account for the deflate header
+            byte[] buffer = new byte[data.Length + 50];
 
             ZStream zs = new()
             {
@@ -88,7 +89,7 @@ namespace SIT.Core.Misc
         public static byte[] Compress(string data)
         {
             // result should hardly be bigger than source data
-            byte[] bytes = new byte[Encoding.UTF8.GetByteCount(data) + 24];
+            byte[] bytes = new byte[Encoding.UTF8.GetByteCount(data) + 50];
             var result = 0;
             do
             {


### PR DESCRIPTION
based on testing by the community. added more bytes to the buffer array to account for deflate header.