### PR TITLE
Fix for the Coop Game breaking while accessing Settings tab while in Raid/Match

### DIFF
--- a/Source/SP/PlayerPatches/Health/MainMenuControllerForHealthListenerPatch.cs
+++ b/Source/SP/PlayerPatches/Health/MainMenuControllerForHealthListenerPatch.cs
@@ -44,12 +44,13 @@ namespace SIT.Core.SP.PlayerPatches.Health
             {
                 listener.Init(healthController, false);
             }
-
-            foreach (var p in GameObject.FindObjectsOfType<CoopPlayer>())
+            if (CoopGameComponent.GetServerId == null)
             {
-                GameObject.Destroy(p);
+                foreach (var p in GameObject.FindObjectsOfType<CoopPlayer>())
+                {
+                    GameObject.Destroy(p);
+                }
             }
-
             listener.Update(healthController, false);
 
         }


### PR DESCRIPTION
This pull request resolves a critical issue in the Coop Game, where players encountered unexpected breakages upon accessing the Settings tab during a Coop match.

I don't know if this is the best way to overcome the issue but this was my fix for it