### PR TITLE
better implementation for server-side authorization check

### DIFF
--- a/Source/Coop/Components/SITMatchmakerGUIComponent.cs
+++ b/Source/Coop/Components/SITMatchmakerGUIComponent.cs
@@ -359,7 +359,7 @@ namespace SIT.Core.Coop.Components
 
             if (GUI.Button(new UnityEngine.Rect(buttonX + 60, halfWindowHeight, 100, 40), "Join"))
             {
-                JoinMatch(pendingServerId, passwordClientInput);
+                JoinMatch(MatchmakerAcceptPatches.Profile.ProfileId, pendingServerId, passwordClientInput);
             }
         }
 
@@ -456,7 +456,7 @@ namespace SIT.Core.Coop.Components
                     if (GUI.Button(new UnityEngine.Rect(cellWidth * 4 + separatorWidth / 2 + 15, yPos + (cellHeight * 0.3f) - 5, cellWidth * 0.8f, cellHeight * 0.6f), StayInTarkovPlugin.LanguageDictionary["JOIN"], buttonStyle))
                     {
                         // Perform actions when the "Join" button is clicked
-                        JoinMatch(match["ServerId"].ToString());
+                        JoinMatch(MatchmakerAcceptPatches.Profile.ProfileId, match["ServerId"].ToString());
                     }
 
                     index++;
@@ -464,9 +464,9 @@ namespace SIT.Core.Coop.Components
             }
         }
 
-        void JoinMatch(string serverId, string password = "")
+        void JoinMatch(string profileId, string serverId, string password = "")
         {
-            if (MatchmakerAcceptPatches.JoinMatch(RaidSettings, serverId, password, out string returnedJson, out string errorMessage))
+            if (MatchmakerAcceptPatches.JoinMatch(RaidSettings, profileId, serverId, password, out string returnedJson, out string errorMessage))
             {
                 Logger.LogDebug(returnedJson);
                 JObject result = JObject.Parse(returnedJson);
@@ -475,7 +475,7 @@ namespace SIT.Core.Coop.Components
                 MatchmakerAcceptPatches.MatchingType = EMatchmakerType.GroupPlayer;
                 MatchmakerAcceptPatches.HostExpectedNumberOfPlayers = int.Parse(result["expectedNumberOfPlayers"].ToString());
 
-                AkiBackendCommunication.Instance.WebSocketCreate(MatchmakerAcceptPatches.Profile, serverId, password);
+                AkiBackendCommunication.Instance.WebSocketCreate(MatchmakerAcceptPatches.Profile);
 
                 FixesHideoutMusclePain();
                 DestroyThis();
@@ -600,7 +600,7 @@ namespace SIT.Core.Coop.Components
                 OriginalAcceptButton.OnClick.Invoke();
                 DestroyThis();
 
-                AkiBackendCommunication.Instance.WebSocketCreate(MatchmakerAcceptPatches.Profile, MatchmakerAcceptPatches.Profile.ProfileId, passwordInput);
+                AkiBackendCommunication.Instance.WebSocketCreate(MatchmakerAcceptPatches.Profile);
             }
         }
 

--- a/Source/Coop/Matchmaker/MatchmakerAccept/MatchmakerAcceptPatches.cs
+++ b/Source/Coop/Matchmaker/MatchmakerAccept/MatchmakerAcceptPatches.cs
@@ -148,7 +148,7 @@ namespace SIT.Coop.Core.Matchmaker
             return false;
         }
 
-        public static bool JoinMatch(RaidSettings settings, string serverId, string password, out string outJson, out string errorMessage)
+        public static bool JoinMatch(RaidSettings settings, string profileId, string serverId, string password, out string outJson, out string errorMessage)
         {
             errorMessage = $"No server matches the data provided or the server no longer exists";
             PatchConstants.Logger.LogDebug("JoinMatch");
@@ -157,6 +157,7 @@ namespace SIT.Coop.Core.Matchmaker
             if (MatchmakerAcceptPatches.MatchMakerAcceptScreenInstance != null)
             {
                 JObject objectToSend = JObject.FromObject(settings);
+                objectToSend.Add("profileId", profileId);
                 objectToSend.Add("serverId", serverId);
                 objectToSend.Add("password", password);
 

--- a/Source/Core/AkiBackendCommunication.cs
+++ b/Source/Core/AkiBackendCommunication.cs
@@ -120,7 +120,7 @@ namespace SIT.Core.Core
 
         private HashSet<string> WebSocketPreviousReceived { get; set; }
 
-        public void WebSocketCreate(Profile profile, string serverId, string password)
+        public void WebSocketCreate(Profile profile)
         {
             MyProfile = profile;
 
@@ -134,7 +134,7 @@ namespace SIT.Core.Core
             Logger.LogDebug("Request Instance is connecting to WebSocket");
 
             var webSocketPort = PluginConfigSettings.Instance.CoopSettings.SITWebSocketPort;
-            var wsUrl = $"{PatchConstants.GetREALWSURL()}:{webSocketPort}/{profile.ProfileId}?serverId={serverId}&password={password}";
+            var wsUrl = $"{PatchConstants.GetREALWSURL()}:{webSocketPort}/{profile.ProfileId}?";
             Logger.LogDebug(webSocketPort);
             Logger.LogDebug(PatchConstants.GetREALWSURL());
             Logger.LogDebug(wsUrl);
@@ -200,7 +200,7 @@ namespace SIT.Core.Core
             Logger.LogError($"{nameof(WebSocket_OnError)}: {e.Exception}");
             WebSocket_OnError();
             WebSocketClose();
-            WebSocketCreate(MyProfile, "", "");
+            WebSocketCreate(MyProfile);
         }
 
         private void WebSocket_OnError()


### PR DESCRIPTION
Goes with with the latest PR on SIT.Aki-Server-Mod.

Provides the profileId (client) and serverId (server) during CreateMatch and JoinMatch to allow building an authorization list on the server side.

Removed previous implementation.