### PR TITLE
change zlib compression level

### DIFF
--- a/Source/Misc/Zlib.cs
+++ b/Source/Misc/Zlib.cs
@@ -65,7 +65,7 @@ namespace SIT.Core.Misc
 
         public static byte[] Compress(string data)
         {
-            return SimpleZlib.CompressToBytes(data, 6);
+            return SimpleZlib.CompressToBytes(data, 9);
         }
 
         public static async Task<byte[]> CompressAsync(string data, ZlibCompression level)


### PR DESCRIPTION
EFT uses compression level 9. people reported occasional unexpected end of file on profile save, so this might fix it.