### PR TITLE
Fix missing Licensing requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ So I ported many of SPT-Aki features into this module. My end-goal would be to r
 - SPT-Aki team
 - MTGA team
 - SPT-Aki Modding Community
+- TheMaoci (Original code from JET Binaries, examples: "LegalGameCopy")
 - DrakiaXYZ ([BigBrain](https://github.com/DrakiaXYZ/SPT-BigBrain))
 - Dvize ([NoBushESP](https://github.com/dvize/NoBushESP))
 - SIT Contributors

--- a/Source/Core/LegalGameCheck.cs
+++ b/Source/Core/LegalGameCheck.cs
@@ -10,6 +10,12 @@ using UnityEngine;
 
 namespace SIT.Core.Core
 {
+    /// <summary>
+    /// This code checks if player has legit game installed. 
+    /// Created by: TheMaoci (included in JET.Core binaries - source code is private) 
+    /// IsGameFound => LegalityCheck
+    /// Info: its "cut version" cause BSG was not bothered with updating variables in registry on each update or installation of the game
+    /// </summary>
     public class LegalGameCheck
     {
         public static string IllegalMessage { get; }


### PR DESCRIPTION
For some reason Readme now doesnt contains me as a creator of some of the scripts...

https://github.com/paulov-t/SIT.Core/commit/13976e307a402e9cf3d31646a7514e9b5a585caa
this is when it disapeared even tho you still uses same code for checking legality (adding 2 more checks on top)